### PR TITLE
Update Dockerfile to fix missing btrfs Issue 17

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM archlinux:base-devel
 STOPSIGNAL SIGRTMIN+3
 
-RUN pacman -Syu --noconfirm --needed python-pipx python-twisted python-future git wget systemd-sysvcompat openresolv vi
+RUN pacman -Syu --noconfirm --needed python-pipx python-twisted python-future git wget systemd-sysvcompat openresolv vi btrfs-progs
 
 # add buildbot user and give passwordless sudo access (needed for archzfs build scripts)
 RUN groupadd -r buildbot && \


### PR DESCRIPTION
After building containers, worker fails to run any builds due to missing command btrfs.  This fix forces pacman to install btrfs-progs explicitly.  Fix for issue 17.